### PR TITLE
ENVIO: implementacion inicial de RF4 (FinalizarEnvio)

### DIFF
--- a/Agencia.DTOs/Agencia.DTOs.csproj
+++ b/Agencia.DTOs/Agencia.DTOs.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="DTOs\EnvioDTO\" />
     <Folder Include="DTOs\ComentarioDTO\" />
   </ItemGroup>
 

--- a/Agencia.DTOs/DTOs/EnvioDTO/DTOEnvio.cs
+++ b/Agencia.DTOs/DTOs/EnvioDTO/DTOEnvio.cs
@@ -13,5 +13,5 @@ public class DTOEnvio
         public double? Peso { get; set; }
         public string? TipoEnvio { get; set; }
         public EstadoEnvio? Estado { get; set; }
-        public List<Comentario>? Comentarios { get; set; }
+        public List<Comentario>? Seguimiento { get; set; }
 }

--- a/Agencia.DTOs/DTOs/EnvioDTO/DTOEnvio.cs
+++ b/Agencia.DTOs/DTOs/EnvioDTO/DTOEnvio.cs
@@ -1,0 +1,17 @@
+using Agencia.LogicaNegocio.Entidades;
+using Agencia.LogicaNegocio.Enumerados.EnvioEnums;
+using Agencia.LogicaNegocio.VO.UsuarioVO;
+
+namespace Agencia.DTOs.DTOs.EnvioDTO;
+
+public class DTOEnvio
+{ 
+        public int? Id { get; set; }
+        public int? NumeroTracking { get; set; }
+        public NombreCompleto? NombreCliente { get; set; }
+        public NombreCompleto? NombreEmpleado { get; set; }
+        public double? Peso { get; set; }
+        public string? TipoEnvio { get; set; }
+        public EstadoEnvio? Estado { get; set; }
+        public List<Comentario>? Comentarios { get; set; }
+}

--- a/Agencia.DTOs/Mappers/MapperEnvio.cs
+++ b/Agencia.DTOs/Mappers/MapperEnvio.cs
@@ -19,6 +19,7 @@ public class MapperEnvio
             dto.Peso = env._peso;
             dto.TipoEnvio = env.GetType().ToString();
             dto.Estado = env._estado; 
+            dto.Seguimiento = env._seguimiento;
             ret.Add(dto);
         }
         return ret;

--- a/Agencia.DTOs/Mappers/MapperEnvio.cs
+++ b/Agencia.DTOs/Mappers/MapperEnvio.cs
@@ -1,0 +1,26 @@
+using Agencia.DTOs.DTOs.EnvioDTO;
+using Agencia.LogicaNegocio.Entidades;
+
+namespace Agencia.DTOs.Mappers;
+
+public class MapperEnvio
+{
+    public static List<DTOEnvio> FromListEnvioToListDto(List<Envio> envios)
+    {
+        List<DTOEnvio> ret = new List<DTOEnvio>();
+
+        foreach (Envio env in envios)
+        {
+            DTOEnvio dto = new DTOEnvio();
+            dto.Id = env.Id;
+            dto.NumeroTracking = env._nroTracking;
+            dto.NombreCliente = env._cliente?._nombreCompleto;
+            dto.NombreEmpleado = env._empleado?._nombreCompleto;
+            dto.Peso = env._peso;
+            dto.TipoEnvio = env.GetType().ToString();
+            dto.Estado = env._estado; 
+            ret.Add(dto);
+        }
+        return ret;
+    }
+}

--- a/Agencia.LogicaAccesoDatos/Repositorios/RepositorioEnvio.cs
+++ b/Agencia.LogicaAccesoDatos/Repositorios/RepositorioEnvio.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Agencia.LogicaNegocio.Enumerados.EnvioEnums;
 
 namespace Agencia.LogicaAccesoDatos.Repositorios
 {
@@ -43,6 +44,12 @@ namespace Agencia.LogicaAccesoDatos.Repositorios
             _context.Envios.Update(obj);
             _context.SaveChanges();
             return obj.Id;
+        }
+
+        public List<Envio> ObtenerEnviosEnProceso()
+        {
+            List<Envio> enviosEnProceso = this.FindAll().Where(e => e._estado == EstadoEnvio.EN_PROCESO).ToList();
+            return enviosEnProceso; 
         }
     }
 }

--- a/Agencia.LogicaAplicacion/Agencia.LogicaAplicacion.csproj
+++ b/Agencia.LogicaAplicacion/Agencia.LogicaAplicacion.csproj
@@ -7,10 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="CasosUso\CUEnvio\" />
     <Folder Include="CasosUso\CUComentario\" />
     <Folder Include="ICasosUso\ICUComentario\" />
-    <Folder Include="ICasosUso\ICUEnvio\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Agencia.LogicaAplicacion/CasosUso/CUEnvio/CUFinalizarEnvio.cs
+++ b/Agencia.LogicaAplicacion/CasosUso/CUEnvio/CUFinalizarEnvio.cs
@@ -1,0 +1,55 @@
+using Agencia.LogicaAplicacion.ICasosUso.ICUEnvio;
+using Agencia.LogicaNegocio.CustomException.EnvioExceptions;
+using Agencia.LogicaNegocio.Entidades;
+using Agencia.LogicaNegocio.Enumerados.AuditoriaEnums;
+using Agencia.LogicaNegocio.InterfacesRepositorios;
+
+namespace Agencia.LogicaAplicacion.CasosUso.CUEnvio;
+
+public class CUFinalizarEnvio : ICUFinalizarEnvio
+{
+    private IRepositorioEnvio _repoEnvio;
+    private IRepositorioAuditoria _repoAuditoria;
+    
+    public CUFinalizarEnvio(IRepositorioEnvio repoEnvio, IRepositorioAuditoria repoAuditoria)
+    {
+        _repoEnvio = repoEnvio;
+        _repoAuditoria = repoAuditoria;
+    }
+    
+    public void FinalizarEnvio(int idEnvio, int idUsuarioLogueado)
+    {
+        try
+        {
+            Envio envioAFinalizar = _repoEnvio.FindById(idEnvio);
+            if (envioAFinalizar == null) throw new EnvioNoEncontradoException("No se encontró el envío.");
+            
+            envioAFinalizar.FinalizarEnvio(); 
+            _repoEnvio.Update(envioAFinalizar);
+            Auditoria aud = Utilidades.Auditor.Auditar(
+                idUsuarioLogueado,
+                Acciones.EDICION,
+                "EXITO",
+                envioAFinalizar.GetType().Name,
+                idEnvio.ToString(),
+                "Finalización de envío exitosa"
+            );
+            _repoAuditoria.Auditar(aud);
+
+
+        }
+        catch (Exception e)
+        {
+            Auditoria aud = Utilidades.Auditor.Auditar(
+                idUsuarioLogueado,
+                Acciones.EDICION,
+                "FALLO",
+                null,
+                null,
+                e.Message
+            );
+            _repoAuditoria.Auditar(aud);
+            throw;
+        }
+    }
+}

--- a/Agencia.LogicaAplicacion/CasosUso/CUEnvio/CUObtenerEnviosEnProceso.cs
+++ b/Agencia.LogicaAplicacion/CasosUso/CUEnvio/CUObtenerEnviosEnProceso.cs
@@ -1,0 +1,25 @@
+using Agencia.DTOs.DTOs.EnvioDTO;
+using Agencia.DTOs.Mappers;
+using Agencia.LogicaAplicacion.ICasosUso.ICUEnvio;
+using Agencia.LogicaNegocio.Entidades;
+using Agencia.LogicaNegocio.Enumerados.EnvioEnums;
+using Agencia.LogicaNegocio.InterfacesRepositorios;
+
+namespace Agencia.LogicaAplicacion.CasosUso.CUEnvio;
+
+public class CUObtenerEnviosEnProceso : ICUObtenerEnviosEnProceso
+{
+    private readonly IRepositorioEnvio _repoEnvio;
+    public CUObtenerEnviosEnProceso(IRepositorioEnvio repoEnvio)
+    {
+        _repoEnvio = repoEnvio;
+    }
+    
+    public List<DTOEnvio> ObtenerEnviosEnProceso()
+    {
+        List<Envio> enviosEnProceso = _repoEnvio.ObtenerEnviosEnProceso();
+        List<DTOEnvio> ret = MapperEnvio.FromListEnvioToListDto(enviosEnProceso);
+        return ret;
+        
+    }
+}

--- a/Agencia.LogicaAplicacion/CasosUso/CUUsuario/CUActualizarFuncionario.cs
+++ b/Agencia.LogicaAplicacion/CasosUso/CUUsuario/CUActualizarFuncionario.cs
@@ -40,14 +40,14 @@ namespace Agencia.LogicaAplicacion.CasosUso.CUUsuario
                 Auditoria aud = Utilidades.Auditor.Auditar(dto.LogueadoId, Acciones.EDICION, "FALLO", null,
                     null, e.Message); 
                 _repoAuditoria.Auditar(aud);
-                throw e;
+                throw;
             }
             catch (Exception e)
             {
                 Auditoria aud = Utilidades.Auditor.Auditar(dto.LogueadoId, Acciones.EDICION, "FALLO", null,
                     null, e.Message);
                 _repoAuditoria.Auditar(aud);
-                throw e;
+                throw;
             }
         }
     }

--- a/Agencia.LogicaAplicacion/CasosUso/CUUsuario/CUAltaUsuario.cs
+++ b/Agencia.LogicaAplicacion/CasosUso/CUUsuario/CUAltaUsuario.cs
@@ -37,7 +37,7 @@ public class CUAltaUsuario : ICUAltaUsuario
         {
             Auditoria aud = Utilidades.Auditor.Auditar(null, Acciones.ALTA, "ERROR", null, null, null);
             _repositorioAuditoria.Auditar(aud);
-            throw ex;
+            throw ;
         }
     }
 }

--- a/Agencia.LogicaAplicacion/CasosUso/CUUsuario/CUEliminarFuncionario.cs
+++ b/Agencia.LogicaAplicacion/CasosUso/CUUsuario/CUEliminarFuncionario.cs
@@ -37,7 +37,7 @@ namespace Agencia.LogicaAplicacion.CasosUso.CUUsuario
                 Auditoria aud = Utilidades.Auditor.Auditar(dto.LogueadoId, Acciones.ELIMINACION, "FALLA", "USUARIO",//usuario.GetType().Name,
                        null, ex.Message);
                 _repoAuditoria.Auditar(aud);
-                throw ex;
+                throw;
             }
         }
     }

--- a/Agencia.LogicaAplicacion/ICasosUso/ICUEnvio/ICUFinalizarEnvio.cs
+++ b/Agencia.LogicaAplicacion/ICasosUso/ICUEnvio/ICUFinalizarEnvio.cs
@@ -1,0 +1,6 @@
+namespace Agencia.LogicaAplicacion.ICasosUso.ICUEnvio;
+
+public interface ICUFinalizarEnvio
+{
+    void FinalizarEnvio(int idEnvio, int idUsuarioLogueado);
+}

--- a/Agencia.LogicaAplicacion/ICasosUso/ICUEnvio/ICUObtenerEnviosEnProceso.cs
+++ b/Agencia.LogicaAplicacion/ICasosUso/ICUEnvio/ICUObtenerEnviosEnProceso.cs
@@ -1,0 +1,9 @@
+using Agencia.DTOs.DTOs.EnvioDTO;
+using Agencia.LogicaNegocio.Entidades;
+
+namespace Agencia.LogicaAplicacion.ICasosUso.ICUEnvio;
+
+public interface ICUObtenerEnviosEnProceso
+{
+    public List<DTOEnvio> ObtenerEnviosEnProceso();
+}

--- a/Agencia.LogicaNegocio/Agencia.LogicaNegocio.csproj
+++ b/Agencia.LogicaNegocio/Agencia.LogicaNegocio.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <Folder Include="CustomException\AgenciaExceptions\" />
     <Folder Include="CustomException\ComentarioExceptions\" />
-    <Folder Include="CustomException\EnvioExceptions\" />
   </ItemGroup>
 
 </Project>

--- a/Agencia.LogicaNegocio/CustomException/EnvioExceptions/EnvioNoEncontradoException.cs
+++ b/Agencia.LogicaNegocio/CustomException/EnvioExceptions/EnvioNoEncontradoException.cs
@@ -1,0 +1,6 @@
+namespace Agencia.LogicaNegocio.CustomException.EnvioExceptions;
+
+public class EnvioNoEncontradoException : Exception
+{
+    public EnvioNoEncontradoException(string? message) : base(message) { }
+}

--- a/Agencia.LogicaNegocio/CustomException/EnvioExceptions/EnvioYaFinalizadoException.cs
+++ b/Agencia.LogicaNegocio/CustomException/EnvioExceptions/EnvioYaFinalizadoException.cs
@@ -1,0 +1,6 @@
+namespace Agencia.LogicaNegocio.CustomException.EnvioExceptions;
+
+public class EnvioYaFinalizadoException : Exception
+{
+    public EnvioYaFinalizadoException(string? message) : base(message) { }
+}

--- a/Agencia.LogicaNegocio/Entidades/Envio.cs
+++ b/Agencia.LogicaNegocio/Entidades/Envio.cs
@@ -4,10 +4,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Agencia.LogicaNegocio.CustomException.EnvioExceptions;
 
 namespace Agencia.LogicaNegocio.Entidades
 {
-    public class Envio
+    public abstract class Envio
     {
         public int Id { get; set; }
 
@@ -25,8 +26,10 @@ namespace Agencia.LogicaNegocio.Entidades
         public EstadoEnvio _estado { get; set; }
 
         public List<Comentario> _seguimiento { get; set; }
+        
+        public DateTime? _fechaEntrega { get; set; }
 
-        public Envio(int nroTracking, Usuario empleado, Usuario cliente, double peso, EstadoEnvio estado, List<Comentario> seguimiento)
+        public Envio(int nroTracking, Usuario empleado, Usuario cliente, double peso, EstadoEnvio estado, List<Comentario> seguimiento, DateTime fechaEntrega)
         {
             _nroTracking = nroTracking;
             _empleado = empleado;
@@ -34,8 +37,20 @@ namespace Agencia.LogicaNegocio.Entidades
             _peso = peso;
             _estado = estado;
             _seguimiento = seguimiento;
+            _fechaEntrega = fechaEntrega;
         }
 
         public Envio() { }
+
+        public abstract void FinalizarEnvio();
+
+        protected void FinalizarEnvioBase()
+        {
+            if (_estado == EstadoEnvio.FINALIZADO)
+                throw new EnvioYaFinalizadoException("El envío ya finalizó");
+
+            _estado = EstadoEnvio.FINALIZADO;
+            _fechaEntrega = DateTime.Now;
+        }
     }
 }

--- a/Agencia.LogicaNegocio/Entidades/EnvioComun.cs
+++ b/Agencia.LogicaNegocio/Entidades/EnvioComun.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Agencia.LogicaNegocio.CustomException.EnvioExceptions;
 
 namespace Agencia.LogicaNegocio.Entidades
 {
@@ -12,10 +13,14 @@ namespace Agencia.LogicaNegocio.Entidades
     {
         public Sucursal _destino { get; set; }
 
-        public EnvioComun(int nroTracking, Usuario empleado, Usuario cliente, double peso, EstadoEnvio estado, List<Comentario> seguimiento, Sucursal destino) : base(nroTracking, empleado, cliente, peso, estado, seguimiento)
+        public EnvioComun(int nroTracking, Usuario empleado, Usuario cliente, double peso, EstadoEnvio estado, List<Comentario> seguimiento, Sucursal destino, DateTime fechaEntrega) : base(nroTracking, empleado, cliente, peso, estado, seguimiento, fechaEntrega)
         {
             _destino = destino;
         }
         public EnvioComun() : base() { }
+        public override void FinalizarEnvio()
+        {
+            FinalizarEnvioBase();
+        }
     }
 }

--- a/Agencia.LogicaNegocio/Entidades/EnvioUrgente.cs
+++ b/Agencia.LogicaNegocio/Entidades/EnvioUrgente.cs
@@ -12,12 +12,28 @@ namespace Agencia.LogicaNegocio.Entidades
         public int _direccionPostal { get; set; }
         public bool _entregado { get; set; }
 
-        public EnvioUrgente(int nroTracking, Usuario empleado, Usuario cliente, double peso, EstadoEnvio estado, List<Comentario> seguimiento, int direccionPostal, bool entregado) : base(nroTracking, empleado, cliente, peso, estado, seguimiento)
+        public EnvioUrgente(
+            int nroTracking,
+            Usuario empleado,
+            Usuario cliente,
+            double peso,
+            EstadoEnvio estado,
+            List<Comentario> seguimiento,
+            DateTime fechaEntrega,
+            int direccionPostal, 
+            bool entregado) 
+            : base(nroTracking, empleado, cliente, peso, estado, seguimiento, fechaEntrega)
         {
             _direccionPostal = direccionPostal;
             _entregado = entregado;
         }
 
         public EnvioUrgente() : base() { }
+
+        public override void FinalizarEnvio()
+        {
+           FinalizarEnvioBase();
+           //TODO CalcularEficiencia();
+        }
     }
 }

--- a/Agencia.LogicaNegocio/InterfacesRepositorios/IRepositorioEnvio.cs
+++ b/Agencia.LogicaNegocio/InterfacesRepositorios/IRepositorioEnvio.cs
@@ -9,5 +9,6 @@ namespace Agencia.LogicaNegocio.InterfacesRepositorios
 {
     public interface IRepositorioEnvio : IRepositorio<Envio>
     {
+        List<Envio> ObtenerEnviosEnProceso();
     }
 }


### PR DESCRIPTION
## RF4: Se listarán los envíos que estén actualmente en proceso y contará con una forma de indicar que fue entregado (finalizado) agregando la fecha.

### - Caso de uso `CUFinalizarEnvio`
### - Caso de uso `CUObtenerEnviosEnProceso` que tambien va a ser necesario para RF5 

devuelve lista de envíos con estado EN_PROCESO (implementé método en `ObtenerEnviosEnProceso` en `RepositorioEnvio`)

### - Entidad Envio 
- Metodo  abstracto `FinalizarEnvio()` que se aplica en EnvioUrgente y EnvioComun y se llama desde CUFinalizarEnvio
- Agregue campo nulleable `_fechaEntrega` para registrar cuándo fue entregado el envío (a chequear si está ok jaja)

### - `DTOEnvio` y Mapper `FromListEnvioToDTOEnvio` 

### - Warnings (cambios en ActualizarFuncionar, ELiminarFuncionario, etc): me aparecía como warning que era mejor sacar el ex de throw ex (dejar solo throw) 
